### PR TITLE
Fix problem status and leaderboard score calculations

### DIFF
--- a/senatus/src/api/event/controllers/event.ts
+++ b/senatus/src/api/event/controllers/event.ts
@@ -138,7 +138,7 @@ const shouldUseTestCaseInLiveScore = (
 		return true;
 	}
 
-	return !testCase.hidden && !testCase.locked;
+	return !testCase.locked;
 };
 
 const getEventRegistrations = async (strapi: any, eventDocumentId: string) =>
@@ -554,7 +554,7 @@ export default factories.createCoreController('api::event.event', ({ strapi }) =
 		);
 
 		const eligibleProblemIds = uniqueProblems
-			.filter((problem) => (problem.testCases || []).some((testCase) => !testCase.hidden && !testCase.locked))
+			.filter((problem) => (problem.testCases || []).some((testCase) => !testCase.locked))
 			.map((problem) => problem.documentId);
 
 		if (eligibleProblemIds.length === 0) {
@@ -608,7 +608,7 @@ export default factories.createCoreController('api::event.event', ({ strapi }) =
 				continue;
 			}
 
-			const scopedCases = (problem.testCases || []).filter((testCase) => !testCase.hidden && !testCase.locked);
+			const scopedCases = (problem.testCases || []).filter((testCase) => !testCase.locked);
 			if (scopedCases.length === 0) {
 				continue;
 			}

--- a/senatus/src/api/submission/controllers/statuses.ts
+++ b/senatus/src/api/submission/controllers/statuses.ts
@@ -1,0 +1,166 @@
+import { getCurrentUser } from '../../../utils/current-user';
+
+export default {
+  async getProblemStatuses(ctx) {
+    const user = await getCurrentUser(strapi, ctx);
+    if (!user) {
+      return ctx.unauthorized('Authentication required');
+    }
+
+    const { eventId, mode } = ctx.query;
+    const isTraining = mode === 'training';
+    const now = Date.now();
+    
+    try {
+      let targetProblems: any[] = [];
+      let eventMap: Record<string, any> = {};
+
+      if (isTraining) {
+        const endedEvents = await strapi.documents('api::event.event').findMany({
+          filters: { end: { $lt: new Date(now).toISOString() } },
+          populate: ['problems', 'problems.testCases'],
+        });
+
+        for (const event of (endedEvents || [])) {
+          if (event.problems) {
+            for (const prob of event.problems) {
+              targetProblems.push(prob);
+              eventMap[prob.documentId] = event; 
+            }
+          }
+        }
+      } else {
+        if (!eventId) {
+          return ctx.badRequest('An eventId parameter is required outside of training mode.');
+        }
+
+        const currentEvent = await strapi.documents('api::event.event').findOne({
+          documentId: eventId as string,
+          populate: ['problems', 'problems.testCases'],
+        });
+
+        if (currentEvent && currentEvent.problems) {
+          targetProblems = currentEvent.problems;
+          for (const prob of targetProblems) {
+            eventMap[prob.documentId] = currentEvent;
+          }
+        }
+      }
+
+      const problemIds = targetProblems.map((p) => p.documentId).filter(Boolean);
+      const statusMap: Record<string, string> = {};
+
+      for (const prob of targetProblems) {
+        statusMap[prob.documentId] = 'not_tried';
+      }
+
+      if (problemIds.length === 0) {
+        return ctx.body = { statuses: statusMap };
+      }
+
+      const submissionFilters: any = {
+        user: { documentId: user.documentId },
+        problem: { documentId: { $in: problemIds } },
+      };
+
+      if (isTraining) {
+        submissionFilters.event = { $null: true };
+      } else {
+        submissionFilters.event = { documentId: eventId };
+      }
+      
+      const submissions = await strapi.documents('api::submission.submission').findMany({
+        filters: submissionFilters,
+        populate: ['executions', 'executions.testCase', 'problem'],
+        sort: 'createdAt:desc',
+      });
+      
+      const submissionsByProblem = new Map<string, any[]>();
+      for (const sub of (submissions || [])) {
+        const probId = sub.problem?.documentId;
+        if (probId) {
+          if (!submissionsByProblem.has(probId)) {
+            submissionsByProblem.set(probId, []);
+          }
+          submissionsByProblem.get(probId)!.push(sub);
+        }
+      }
+
+      for (const problem of targetProblems) {
+        const problemSubmissions = submissionsByProblem.get(problem.documentId) || [];
+        
+        if (problemSubmissions.length === 0) {
+          continue;
+        }
+
+        const parentEvent = eventMap[problem.documentId];
+        const eventEnded = parentEvent?.end ? new Date(parentEvent.end).getTime() <= now : false;
+
+        const isTestcaseCounted = (tc?: { hidden?: boolean; locked?: boolean }) => {
+          if (!tc) return true;
+          if (isTraining || eventEnded) return true; 
+          return !tc.locked; 
+        };
+
+        const totalCountedTCs = (problem.testCases || []).filter((tc: any) => isTestcaseCounted(tc)).length;
+
+        const calculatePassedCount = (sub: any) => {
+          const relevantExecutions = (sub.executions || []).filter((exec: any) => 
+            isTestcaseCounted(exec.testCase)
+          );
+          return relevantExecutions.filter((exec: any) => exec.processed && exec.passed).length;
+        };
+
+        let finalPassedCount = 0;
+        let finalExpectedCount = totalCountedTCs;
+        let hasEvaluatedSubmission = false;
+
+        if (isTraining) {
+          let maxPassed = -1;
+          
+          for (const sub of problemSubmissions) {
+            const passed = calculatePassedCount(sub);
+            if (passed > maxPassed) {
+              maxPassed = passed;
+              hasEvaluatedSubmission = true;
+              
+              const relevantExecutionsCount = (sub.executions || []).filter((exec: any) => 
+                isTestcaseCounted(exec.testCase)
+              ).length;
+              finalExpectedCount = totalCountedTCs || relevantExecutionsCount;
+            }
+          }
+          finalPassedCount = maxPassed;
+        } else {
+          const latestSubmission = problemSubmissions[0];
+          if (latestSubmission) {
+            finalPassedCount = calculatePassedCount(latestSubmission);
+            hasEvaluatedSubmission = true;
+
+            const relevantExecutionsCount = (latestSubmission.executions || []).filter((exec: any) => 
+              isTestcaseCounted(exec.testCase)
+            ).length;
+            finalExpectedCount = totalCountedTCs || relevantExecutionsCount;
+          }
+        }
+
+        if (!hasEvaluatedSubmission) {
+          continue;
+        }
+
+        if (finalExpectedCount <= 0 || finalPassedCount <= 0) {
+          statusMap[problem.documentId] = 'zero';
+        } else if (finalPassedCount >= finalExpectedCount) {
+          statusMap[problem.documentId] = 'full';
+        } else {
+          statusMap[problem.documentId] = 'partial';
+        }
+      }
+
+      ctx.body = { statuses: statusMap };
+    } catch (err) {
+      console.error(err);
+      ctx.body = { error: 'Failed to fetch problem statuses' };
+    }
+  }
+}

--- a/senatus/src/api/submission/routes/0-statuses.ts
+++ b/senatus/src/api/submission/routes/0-statuses.ts
@@ -1,0 +1,13 @@
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/submissions/statuses',
+      handler: 'api::submission.statuses.getProblemStatuses', // Calls our new file/method
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+  ],
+};

--- a/senatus/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/senatus/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2026-03-01T17:24:56.432Z"
+    "x-generation-date": "2026-05-24T22:46:22.418Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/web/src/pages/EventDetailPage.tsx
+++ b/web/src/pages/EventDetailPage.tsx
@@ -33,27 +33,6 @@ interface Event {
   supportedLanguages?: any[];
 }
 
-interface SubmissionExecution {
-  processed: boolean;
-  passed?: boolean;
-  stdout?: string;
-  testCase?: {
-    output?: string;
-    hidden?: boolean;
-    locked?: boolean;
-  };
-}
-
-interface ProblemSubmission {
-  documentId: string;
-  createdAt: string;
-  problem?: {
-    documentId: string;
-    leaderboardVisibilityMode?: 'public_only_live' | 'full_live';
-  };
-  executions?: SubmissionExecution[];
-}
-
 type ProblemStatus = 'not_tried' | 'zero' | 'partial' | 'full';
 
 interface LeaderboardProblem {
@@ -158,18 +137,6 @@ export default function EventDetailPage() {
   const [questionsError, setQuestionsError] = useState<string | null>(null);
   const [questionDraft, setQuestionDraft] = useState('');
   const [isSubmittingQuestion, setIsSubmittingQuestion] = useState(false);
-
-  const isExecutionPassed = (execution: SubmissionExecution) => {
-    if (!execution?.processed) {
-      return false;
-    }
-
-    if (typeof execution.passed === 'boolean') {
-      return execution.passed;
-    }
-
-    return (execution.stdout || '').trim() === (execution.testCase?.output || '').trim();
-  };
 
   const getProblemStatusClass = (status: ProblemStatus | undefined) => {
     switch (status) {
@@ -426,7 +393,7 @@ export default function EventDetailPage() {
       try {
         const token = localStorage.getItem('jwt');
         const response = await fetch(
-          `${REST_URL}/submissions?filters[event][documentId][$eq]=${eventId}&populate[problem][fields][0]=documentId&populate[problem][fields][1]=leaderboardVisibilityMode&populate[executions][fields][0]=processed&populate[executions][fields][1]=passed&populate[executions][fields][2]=stdout&populate[executions][populate][testCase][fields][0]=output&populate[executions][populate][testCase][fields][1]=hidden&populate[executions][populate][testCase][fields][2]=locked&sort=createdAt:desc`,
+          `${REST_URL}/submissions/statuses?eventId=${eventId}`,
           {
             headers: {
               Authorization: token ? `Bearer ${token}` : '',
@@ -439,62 +406,11 @@ export default function EventDetailPage() {
         }
 
         const data = await response.json();
-        const submissions = (Array.isArray(data) ? data : (data.data || [])) as ProblemSubmission[];
-
-        const latestByProblem = new Map<string, ProblemSubmission>();
-        for (const submission of submissions) {
-          const problemDocumentId = submission.problem?.documentId;
-          if (!problemDocumentId || latestByProblem.has(problemDocumentId)) {
-            continue;
-          }
-
-          latestByProblem.set(problemDocumentId, submission);
-        }
-
         const nextStatusById: Record<string, ProblemStatus> = {};
-        const eventEnded = event.end ? new Date(event.end).getTime() <= Date.now() : false;
-
-        for (const problem of event.problems || []) {
-          const latestSubmission = latestByProblem.get(problem.documentId);
-          if (!latestSubmission) {
-            nextStatusById[problem.documentId] = 'not_tried';
-            continue;
-          }
-
-          const mode = problem.leaderboardVisibilityMode || 'public_only_live';
-          const shouldUseInLiveStatus = (testCase?: { hidden?: boolean; locked?: boolean }) => {
-            // Some interactive execution payloads can miss testCase relation in this
-            // endpoint. Treat them as visible fallback so solved statuses are counted.
-            if (!testCase) {
-              return true;
-            }
-
-            if (eventEnded || mode === 'full_live') {
-              return true;
-            }
-
-            return !testCase.hidden && !testCase.locked;
-          };
-
-          const scopedCountFromProblem = (problem.testCases || []).filter((testCase: any) =>
-            shouldUseInLiveStatus(testCase)
-          ).length;
-          const scopedExecutionResults = (latestSubmission.executions || []).filter(
-            (execution) => shouldUseInLiveStatus(execution.testCase),
-          );
-
-          const visibleCount = scopedCountFromProblem || scopedExecutionResults.length;
-          const passedCount = scopedExecutionResults.filter((execution) => isExecutionPassed(execution)).length;
-
-          if (visibleCount <= 0) {
-            nextStatusById[problem.documentId] = 'zero';
-          } else if (passedCount <= 0) {
-            nextStatusById[problem.documentId] = 'zero';
-          } else if (passedCount >= visibleCount) {
-            nextStatusById[problem.documentId] = 'full';
-          } else {
-            nextStatusById[problem.documentId] = 'partial';
-          }
+        if (data && data.statuses) {
+          Object.entries(data.statuses).forEach(([problemId, statusValue]) => {
+            nextStatusById[problemId] = statusValue as ProblemStatus;
+          });
         }
 
         setProblemStatusById(nextStatusById);

--- a/web/src/pages/TrainingPage.tsx
+++ b/web/src/pages/TrainingPage.tsx
@@ -21,29 +21,6 @@ interface EventItem {
   problems?: EventProblem[];
 }
 
-interface SubmissionExecution {
-  processed: boolean;
-  passed?: boolean;
-  stdout?: string;
-  testCase?: {
-    output?: string;
-    hidden?: boolean;
-    locked?: boolean;
-  };
-}
-
-interface TrainingSubmission {
-  documentId: string;
-  createdAt: string;
-  metadata?: {
-    mode?: string;
-  };
-  problem?: {
-    documentId: string;
-  };
-  executions?: SubmissionExecution[];
-}
-
 type ProblemStatus = 'not_tried' | 'zero' | 'partial' | 'full';
 
 export default function TrainingPage() {
@@ -52,18 +29,6 @@ export default function TrainingPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [problemStatusById, setProblemStatusById] = useState<Record<string, ProblemStatus>>({});
-
-  const isExecutionPassed = (execution: SubmissionExecution) => {
-    if (!execution?.processed) {
-      return false;
-    }
-
-    if (typeof execution.passed === 'boolean') {
-      return execution.passed;
-    }
-
-    return (execution.stdout || '').trim() === (execution.testCase?.output || '').trim();
-  };
 
   const getProblemStatusClass = (status: ProblemStatus | undefined) => {
     switch (status) {
@@ -137,22 +102,8 @@ export default function TrainingPage() {
 
       try {
         const token = localStorage.getItem('jwt');
-        const params = new URLSearchParams();
 
-        uniqueProblemIds.forEach((id, index) => {
-          params.append(`filters[problem][documentId][$in][${index}]`, id);
-        });
-
-        params.append('populate[problem][fields][0]', 'documentId');
-        params.append('populate[executions][fields][0]', 'processed');
-        params.append('populate[executions][fields][1]', 'passed');
-        params.append('populate[executions][fields][2]', 'stdout');
-        params.append('populate[executions][populate][testCase][fields][0]', 'output');
-        params.append('populate[executions][populate][testCase][fields][1]', 'hidden');
-        params.append('populate[executions][populate][testCase][fields][2]', 'locked');
-        params.append('sort', 'createdAt:desc');
-
-        const response = await fetch(`${REST_URL}/submissions?${params.toString()}`, {
+        const response = await fetch(`${REST_URL}/submissions/statuses?mode=training`, {
           headers: {
             Authorization: token ? `Bearer ${token}` : '',
           },
@@ -164,42 +115,12 @@ export default function TrainingPage() {
         }
 
         const data = await response.json();
-        const submissions = (Array.isArray(data) ? data : (data.data || [])) as TrainingSubmission[];
-        const practiceSubmissions = submissions.filter((submission) => submission?.metadata?.mode === 'practice');
-
-        const latestByProblem = new Map<string, TrainingSubmission>();
-        for (const submission of practiceSubmissions) {
-          const problemId = submission.problem?.documentId;
-          if (!problemId || latestByProblem.has(problemId)) {
-            continue;
-          }
-
-          latestByProblem.set(problemId, submission);
-        }
-
         const nextStatuses: Record<string, ProblemStatus> = {};
-        uniqueProblemIds.forEach((problemId) => {
-          const latest = latestByProblem.get(problemId);
-          if (!latest) {
-            nextStatuses[problemId] = 'not_tried';
-            return;
-          }
-
-          const visibleExecutions = (latest.executions || []).filter(
-            (execution) => execution.testCase && !execution.testCase.hidden && !execution.testCase.locked,
-          );
-
-          const visibleCount = visibleExecutions.length;
-          const passedCount = visibleExecutions.filter((execution) => isExecutionPassed(execution)).length;
-
-          if (visibleCount <= 0 || passedCount <= 0) {
-            nextStatuses[problemId] = 'zero';
-          } else if (passedCount >= visibleCount) {
-            nextStatuses[problemId] = 'full';
-          } else {
-            nextStatuses[problemId] = 'partial';
-          }
-        });
+        if (data && data.statuses) {
+          Object.entries(data.statuses).forEach(([problemId, statusValue]) => {
+            nextStatuses[problemId] = statusValue as ProblemStatus;
+          });
+        }
 
         setProblemStatusById(nextStatuses);
       } catch (err) {


### PR DESCRIPTION
## What has been done?

 - Fix live leaderboard score calculations by including hidden test cases.
 - Created a new API endpoint for problem statuses (GET /api/submissions/statuses) to move status calculations from the frontend to the backend. It accepts the parameter mode=training for the training page, or event=eventId for a specific event.
 - Fixed the problem status calculations to work as intended. In an active event, the locked test cases aren't considered, otherwise (in past events and the training page) all test cases are considered.
 - In the training page, the status of the best submission is taken, while for events, it stays as the last submission.
 - Updated the frontend to use the new API endpoint and removed the status calculations there.
