### PR TITLE
Show related problem in tutorial details page

### DIFF
--- a/senatus/src/api/tutorial/controllers/tutorial.ts
+++ b/senatus/src/api/tutorial/controllers/tutorial.ts
@@ -3,5 +3,16 @@
  */
 
 import { factories } from '@strapi/strapi'
+export default factories.createCoreController(
+  'api::tutorial.tutorial',
+  ({ strapi }) => ({
+    async find(ctx) {
+      const data = await strapi.documents('api::tutorial.tutorial').findMany({
+        ...ctx.query,
+        populate: ['thumbnail', 'relatedProblem'],
+      });
 
-export default factories.createCoreController('api::tutorial.tutorial');
+      return { data };
+    }
+  })
+);


### PR DESCRIPTION
## What has been done?

 - Fixed the tutorial details page to display the related problem link.
 - Updated the tutorial controller to explicitly populate the thumbnail and relatedProblem relations.

## Sceenshots/Videos

<img width="1161" height="421" alt="image" src="https://github.com/user-attachments/assets/89d0f20f-cdec-460c-b3ab-324a8bdbb190" />

<img width="1161" height="479" alt="image" src="https://github.com/user-attachments/assets/54b28206-fb93-4c52-a167-7ffd6ed72d82" />

